### PR TITLE
Set data on original event for firefox to fire subsequent events

### DIFF
--- a/lib/knockout.dragdrop.js
+++ b/lib/knockout.dragdrop.js
@@ -126,6 +126,7 @@
 
                 ko.utils.registerEventHandler(element, 'dragstart', function (event) {
                     setSource(zone, element);
+                    event.originalEvent.dataTransfer.setData('text/plain','');
                     if (effect) {
                         event.dataTransfer.effectAllowed = effect;
                     }


### PR DESCRIPTION
Drag and drop in Firefox apparently needs the dataTransfer.setData to be called in the event
(see http://stackoverflow.com/questions/19055264/why-doesnt-html5-drag-and-drop-work-in-firefox).